### PR TITLE
Add DSE Search Queries (using Solr) to the Cassandra Source Connector

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -38,7 +38,7 @@ trait CassandraSetting
 
 object TimestampType extends Enumeration {
   type TimestampType = Value
-  val TIMESTAMP, SOLRTIMESTAMP, TIMEUUID, TOKEN, NONE = Value
+  val TIMESTAMP, DSESEARCHTIMESTAMP, TIMEUUID, TOKEN, NONE = Value
 }
 
 case class CassandraSourceSetting(kcql: Kcql,

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -38,7 +38,7 @@ trait CassandraSetting
 
 object TimestampType extends Enumeration {
   type TimestampType = Value
-  val TIMESTAMP, TIMEUUID, TOKEN, NONE = Value
+  val TIMESTAMP, SOLRTIMESTAMP, TIMEUUID, TOKEN, NONE = Value
 }
 
 case class CassandraSourceSetting(kcql: Kcql,

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -180,8 +180,10 @@ class CassandraTableReader(private val name: String,
     val formattedNow = upperBound.toString()
     val bound = if (isDSESearchBased) {
       val solrWhere = s"$primaryKeyCol:{$formattedPrevious TO $formattedNow]"
-      logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($solrWhere).")
-      preparedStatement.bind(solrWhere)
+      // we need that to be able to page results even with the solr_query being used, that's why we use the paging and sort configs
+      val solrQuery = "{\"q\": \"" + solrWhere + "\", \"sort\":\"" + primaryKeyCol + " asc\", \"paging\":\"driver\"}"
+      logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($solrQuery).")
+      preparedStatement.bind(solrQuery)
     } else {
       logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow).")
       preparedStatement.bind(Date.from(previous), Date.from(upperBound))

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -74,7 +74,7 @@ class CassandraTableReader(private val name: String,
   private var schema: Option[Schema] = None
   private val ignoreList = config.getIgnoredFields.map(_.getName).toSet
   private val isTokenBased = cqlGenerator.isTokenBased()
-  private val isSolrBased = cqlGenerator.isSolrBased()
+  private val isDSESearchBased = cqlGenerator.isDSESearchBased()
   private val cassandraTypeConverter : CassandraTypeConverter =
     new CassandraTypeConverter(session.getCluster.getConfiguration.getCodecRegistry, setting)
   private var structColDefs: List[ColumnDefinitions.Definition] = _
@@ -178,7 +178,7 @@ class CassandraTableReader(private val name: String,
     // logging the CQL
     val formattedPrevious = previous.toString()
     val formattedNow = upperBound.toString()
-    val bound = if (isSolrBased) {
+    val bound = if (isDSESearchBased) {
       val solrWhere = s"$primaryKeyCol:{$formattedPrevious TO $formattedNow]"
       logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($solrWhere).")
       preparedStatement.bind(solrWhere)

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -84,15 +84,23 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
 
   def getDefaultOffsetValue(offset: Option[String]): Option[String] = {
     incrementMode match {
-      case TimestampType.TIMESTAMP | TimestampType.TIMEUUID | TimestampType.NONE => Some(offset.getOrElse(defaultTimestamp))
+      case TimestampType.TIMESTAMP | TimestampType.SOLRTIMESTAMP |
+           TimestampType.TIMEUUID | TimestampType.NONE => Some(offset.getOrElse(defaultTimestamp))
       case TimestampType.TOKEN => offset
     }
   }
 
   def isTokenBased(): Boolean = {
     incrementMode match {
-      case TimestampType.TIMESTAMP | TimestampType.TIMEUUID  | TimestampType.NONE => false
+      case TimestampType.TIMESTAMP | TimestampType.SOLRTIMESTAMP | TimestampType.TIMEUUID | TimestampType.NONE => false
       case TimestampType.TOKEN => true
+    }
+  }
+
+  def isSolrBased(): Boolean = {
+    incrementMode match {
+      case TimestampType.TIMESTAMP | TimestampType.TOKEN | TimestampType.TIMEUUID | TimestampType.NONE => false
+      case TimestampType.SOLRTIMESTAMP => true
     }
   }
 
@@ -149,7 +157,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
   private def generateCqlForSolrTimestampMode: String = {
     val pkCol = setting.primaryKeyColumn.getOrElse("")
     checkCqlForPrimaryKey(pkCol)
-    val whereClause = s" WHERE solr_query='$pkCol:{? TO ?]'"
+    val whereClause = s" WHERE solr_query=?"
     generateCqlForBulkMode + whereClause
   }
 

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -49,6 +49,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
         case TimestampType.TIMEUUID => generateCqlForTimeUuidMode
         case TimestampType.TIMESTAMP => generateCqlForTimestampMode
         case TimestampType.TOKEN => generateCqlForTokenMode
+        case TimestampType.SOLRTIMESTAMP => generateCqlForSolrTimestampMode
         case _ => throw new ConfigException(s"Unknown incremental mode ($incrementMode)")
       }
     }
@@ -73,6 +74,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
         case TimestampType.TIMEUUID => generateCqlForTimeUuidMode
         case TimestampType.TIMESTAMP => generateCqlForTimestampMode
         case TimestampType.TOKEN => generateCqlForTokenModeNoOffset
+        case TimestampType.SOLRTIMESTAMP => generateCqlForSolrTimestampMode
         case _ => throw new ConfigException(s"unknown incremental mode ($incrementMode)")
       }
     }
@@ -141,6 +143,13 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
     val pkCol = setting.primaryKeyColumn.getOrElse("")
     checkCqlForPrimaryKey(pkCol)
     val whereClause = s" WHERE $pkCol > ? AND $pkCol <= ? ALLOW FILTERING"
+    generateCqlForBulkMode + whereClause
+  }
+
+  private def generateCqlForSolrTimestampMode: String = {
+    val pkCol = setting.primaryKeyColumn.getOrElse("")
+    checkCqlForPrimaryKey(pkCol)
+    val whereClause = s" WHERE solr_query='$pkCol:{? TO ?]'"
     generateCqlForBulkMode + whereClause
   }
 

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -49,7 +49,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
         case TimestampType.TIMEUUID => generateCqlForTimeUuidMode
         case TimestampType.TIMESTAMP => generateCqlForTimestampMode
         case TimestampType.TOKEN => generateCqlForTokenMode
-        case TimestampType.SOLRTIMESTAMP => generateCqlForSolrTimestampMode
+        case TimestampType.DSESEARCHTIMESTAMP => generateCqlForDseSearchTimestampMode
         case _ => throw new ConfigException(s"Unknown incremental mode ($incrementMode)")
       }
     }
@@ -74,7 +74,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
         case TimestampType.TIMEUUID => generateCqlForTimeUuidMode
         case TimestampType.TIMESTAMP => generateCqlForTimestampMode
         case TimestampType.TOKEN => generateCqlForTokenModeNoOffset
-        case TimestampType.SOLRTIMESTAMP => generateCqlForSolrTimestampMode
+        case TimestampType.DSESEARCHTIMESTAMP => generateCqlForDseSearchTimestampMode
         case _ => throw new ConfigException(s"unknown incremental mode ($incrementMode)")
       }
     }
@@ -84,7 +84,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
 
   def getDefaultOffsetValue(offset: Option[String]): Option[String] = {
     incrementMode match {
-      case TimestampType.TIMESTAMP | TimestampType.SOLRTIMESTAMP |
+      case TimestampType.TIMESTAMP | TimestampType.DSESEARCHTIMESTAMP |
            TimestampType.TIMEUUID | TimestampType.NONE => Some(offset.getOrElse(defaultTimestamp))
       case TimestampType.TOKEN => offset
     }
@@ -92,15 +92,15 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
 
   def isTokenBased(): Boolean = {
     incrementMode match {
-      case TimestampType.TIMESTAMP | TimestampType.SOLRTIMESTAMP | TimestampType.TIMEUUID | TimestampType.NONE => false
+      case TimestampType.TIMESTAMP | TimestampType.DSESEARCHTIMESTAMP | TimestampType.TIMEUUID | TimestampType.NONE => false
       case TimestampType.TOKEN => true
     }
   }
 
-  def isSolrBased(): Boolean = {
+  def isDSESearchBased(): Boolean = {
     incrementMode match {
       case TimestampType.TIMESTAMP | TimestampType.TOKEN | TimestampType.TIMEUUID | TimestampType.NONE => false
-      case TimestampType.SOLRTIMESTAMP => true
+      case TimestampType.DSESEARCHTIMESTAMP => true
     }
   }
 
@@ -154,7 +154,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
     generateCqlForBulkMode + whereClause
   }
 
-  private def generateCqlForSolrTimestampMode: String = {
+  private def generateCqlForDseSearchTimestampMode: String = {
     val pkCol = setting.primaryKeyColumn.getOrElse("")
     checkCqlForPrimaryKey(pkCol)
     val whereClause = s" WHERE solr_query=?"

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -53,7 +53,7 @@ class TestCqlGenerator extends WordSpec
     val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=solrtimestamp"))
     val cqlStatement = cqlGenerator.getCqlStatement
 
-    cqlStatement shouldBe "SELECT string_field,the_pk_field FROM test.cassandra-table WHERE solr_query='the_pk_field:{? TO ?]'"
+    cqlStatement shouldBe "SELECT string_field,the_pk_field FROM test.cassandra-table WHERE solr_query=?"
   }
 
   "CqlGenerator should generate token based CQL statement based on KCQL" in {

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -48,6 +48,14 @@ class TestCqlGenerator extends WordSpec
     cqlStatement shouldBe "SELECT string_field,the_pk_field FROM test.cassandra-table WHERE the_pk_field > ? AND the_pk_field <= ? ALLOW FILTERING"
   }
 
+  "CqlGenerator should generate solr timestamp statement based on KCQL" in {
+
+    val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=solrtimestamp"))
+    val cqlStatement = cqlGenerator.getCqlStatement
+
+    cqlStatement shouldBe "SELECT string_field,the_pk_field FROM test.cassandra-table WHERE solr_query='the_pk_field:{? TO ?]'"
+  }
+
   "CqlGenerator should generate token based CQL statement based on KCQL" in {
 
     val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=token"))

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -48,9 +48,9 @@ class TestCqlGenerator extends WordSpec
     cqlStatement shouldBe "SELECT string_field,the_pk_field FROM test.cassandra-table WHERE the_pk_field > ? AND the_pk_field <= ? ALLOW FILTERING"
   }
 
-  "CqlGenerator should generate solr timestamp statement based on KCQL" in {
+  "CqlGenerator should generate dse search timestamp statement based on KCQL" in {
 
-    val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=solrtimestamp"))
+    val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=dsesearchtimestamp"))
     val cqlStatement = cqlGenerator.getCqlStatement
 
     cqlStatement shouldBe "SELECT string_field,the_pk_field FROM test.cassandra-table WHERE solr_query=?"


### PR DESCRIPTION
Adds the ability to run DSE Search Queries on the Cassandra Source Connector.

**Motivation**
Today we're using the stream-reactor Cassandra Source Connector to stream some data from a DSE cluster into some Kafka Topics, with stream-reactor we only have the possibility to make Cassandra queries directly. With DSE we have Solr directly integrated with Cassandra giving us the ability to run Solr queries when the search index is available for the table, in most of the cases Solr queries are faster than Cassandra ones and we don't need to use ALLOW FILTERING on the queries.

This PR adds a new INCREMENTALMODE (dsesearchtimestamp) that will add the possibility to make DSE Search queries on a DSE cluster to be able to speed up those queries when the user has a DSE Cluster.

**What we did**
We just added a new INCREMENTALMODE called **dsesearchtimestamp** that will make a DSE Search queries using Solr instead of a native Cassandra query.

Instead of the native query:
```
SELECT a, b, c, d FROM keyspace.table WHERE pkCol > ? AND pkCol <= ? ALLOW FILTERING;
```

We will have now the query with Solr on the dsesearchtimestamp INCREMENTALMODE:
```
SELECT a, b, c, d FROM keyspace.table WHERE solr_query=?;
```

Where the `solr_query` will be something like this:
```
pkCol:{2020-03-23T15:02:21Z TO 2020-03-23T15:30:12.989Z]
```

**Testing**
You gonna find a new test case on the TestCqlGenerator.

I would probably have implemented two new tests called `TestCassandraSourceTaskDSESearchTimestamp` and `TestCassandraSourceTaskDSESearchTimestampLong` but I didn't find an easy way to do that as the custom index for Solr is not being a requirement inside the project. I would appreciate a little help from you guys on how to implement this.

**Why we don't bind the timestamps**
You're probably asking yourself why we don't bind the timestamps directly on the CQL generated query. That was the idea first but we realized that CQL doesn't allow to bind variables inside a string, so we couldn't do something like that:

```
SELECT a, b, c, d FROM keyspace.table WHERE solr_query='pkCol:{? TO ?]';
```

That's why we mount the Solr query on `CassandraTableReader` and then bind it inside the solr_query.