### PR TITLE
Add Bucket TimeSeries mode to the Cassandra Source Connector

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -362,6 +362,16 @@ object CassandraConfigSource {
       ConfigDef.Width.LONG,
       CassandraConfigConstants.BUCKET_TIME_SERIES_FORMAT)
 
+    .define(CassandraConfigConstants.BUCKET_TIME_SERIES_FIELD_NAME,
+      Type.STRING,
+      CassandraConfigConstants.BUCKET_TIME_SERIES_FIELD_NAME_DEFAULT,
+      Importance.MEDIUM,
+      CassandraConfigConstants.BUCKET_TIME_SERIES_FIELD_NAME_DOC,
+      "Import",
+      13,
+      ConfigDef.Width.LONG,
+      CassandraConfigConstants.BUCKET_TIME_SERIES_FIELD_NAME)
+
 }
 
 case class CassandraConfigSource(props: util.Map[String, String])

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -342,6 +342,26 @@ object CassandraConfigSource {
       ConfigDef.Width.LONG,
       CassandraConfigConstants.MAPPING_COLLECTION_TO_JSON)
 
+    .define(CassandraConfigConstants.BUCKET_TIME_SERIES_MODE,
+      Type.STRING,
+      "",
+      Importance.MEDIUM,
+      CassandraConfigConstants.BUCKET_TIME_SERIES_MODE_DOC,
+      "Import",
+      12,
+      ConfigDef.Width.LONG,
+      CassandraConfigConstants.BUCKET_TIME_SERIES_MODE)
+
+    .define(CassandraConfigConstants.BUCKET_TIME_SERIES_FORMAT,
+      Type.STRING,
+      "",
+      Importance.MEDIUM,
+      CassandraConfigConstants.BUCKET_TIME_SERIES_FORMAT_DOC,
+      "Import",
+      13,
+      ConfigDef.Width.LONG,
+      CassandraConfigConstants.BUCKET_TIME_SERIES_FORMAT)
+
 }
 
 case class CassandraConfigSource(props: util.Map[String, String])

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -199,6 +199,10 @@ object CassandraConfigConstants {
   val BUCKET_TIME_SERIES_FORMAT = s"$CONNECTOR_PREFIX.bucket.timeseries.format"
   val BUCKET_TIME_SERIES_FORMAT_DOC = "The bucket format to retrieve timeseries data"
 
+  val BUCKET_TIME_SERIES_FIELD_NAME = s"$CONNECTOR_PREFIX.bucket.timeseries.field.name"
+  val BUCKET_TIME_SERIES_FIELD_NAME_DOC = "The name of the field to use on bucket"
+  val BUCKET_TIME_SERIES_FIELD_NAME_DEFAULT = "bucket"
+
   val DEFAULT_VALUE_SERVE_STRATEGY_PROPERTY = s"$CONNECTOR_PREFIX.default.value"
   val DEFAULT_VALUE_SERVE_STRATEGY_DOC =
     """

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -193,6 +193,12 @@ object CassandraConfigConstants {
   val MAPPING_COLLECTION_TO_JSON_DOC = "Mapping columns with type Map, List and Set like json"
   val MAPPING_COLLECTION_TO_JSON_DEFAULT = true
 
+  val BUCKET_TIME_SERIES_MODE = s"$CONNECTOR_PREFIX.bucket.timeseries.mode"
+  val BUCKET_TIME_SERIES_MODE_DOC = "The bucket mode to retrieve timeseries data. DAY, HOUR, MINUTE, SECOND."
+
+  val BUCKET_TIME_SERIES_FORMAT = s"$CONNECTOR_PREFIX.bucket.timeseries.format"
+  val BUCKET_TIME_SERIES_FORMAT_DOC = "The bucket format to retrieve timeseries data"
+
   val DEFAULT_VALUE_SERVE_STRATEGY_PROPERTY = s"$CONNECTOR_PREFIX.default.value"
   val DEFAULT_VALUE_SERVE_STRATEGY_DOC =
     """

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -17,6 +17,7 @@
 package com.datamountaineer.streamreactor.connect.cassandra.config
 
 import com.datamountaineer.kcql.{Field, Kcql}
+import com.datamountaineer.streamreactor.connect.cassandra.config.BucketMode.BucketMode
 import com.datamountaineer.streamreactor.connect.cassandra.config.DefaultValueServeStrategy.DefaultValueServeStrategy
 import com.datamountaineer.streamreactor.connect.cassandra.config.TimestampType.TimestampType
 import com.datamountaineer.streamreactor.connect.errors.{ErrorPolicy, ThrowErrorPolicy}
@@ -36,7 +37,12 @@ trait CassandraSetting
 
 object TimestampType extends Enumeration {
   type TimestampType = Value
-  val TIMESTAMP, DSESEARCHTIMESTAMP, TIMEUUID, TOKEN, NONE = Value
+  val TIMESTAMP, DSESEARCHTIMESTAMP, TIMEUUID, TOKEN, BUCKETTIMESERIES, NONE = Value
+}
+
+object BucketMode extends Enumeration {
+  type BucketMode = Value
+  val DAY, HOUR, MINUTE, SECOND, NONE = Value
 }
 
 object LoadBalancingPolicy extends Enumeration {
@@ -57,7 +63,9 @@ case class CassandraSourceSetting(kcql: Kcql,
                                   timeSliceDelay: Long = CassandraConfigConstants.TIMESLICE_DELAY_DEFAULT,
                                   initialOffset: String = CassandraConfigConstants.INITIAL_OFFSET_DEFAULT,
                                   timeSliceMillis: Long = CassandraConfigConstants.TIME_SLICE_MILLIS_DEFAULT,
-                                  mappingCollectionToJson: Boolean = CassandraConfigConstants.MAPPING_COLLECTION_TO_JSON_DEFAULT
+                                  mappingCollectionToJson: Boolean = CassandraConfigConstants.MAPPING_COLLECTION_TO_JSON_DEFAULT,
+                                  bucketMode: BucketMode,
+                                  bucketFormat: String
                                  ) extends CassandraSetting
 
 case class CassandraSinkSetting(keySpace: String,
@@ -88,6 +96,8 @@ object CassandraSettings extends StrictLogging {
     require(!keySpace.isEmpty, CassandraConfigConstants.MISSING_KEY_SPACE_MESSAGE)
     val pollInterval = config.getLong(CassandraConfigConstants.POLL_INTERVAL)
 
+    val bucketFormat = config.getString(CassandraConfigConstants.BUCKET_TIME_SERIES_FORMAT)
+
     val consistencyLevel = config.getConsistencyLevel
     val errorPolicy = config.getErrorPolicy
     val kcqls = config.getKCQL
@@ -105,6 +115,19 @@ object CassandraSettings extends StrictLogging {
       val timestampType = Try(TimestampType.withName(incrementalModes(r.getSource).toUpperCase)) match {
         case Success(s) => s
         case _ => TimestampType.NONE
+      }
+
+      val bucketMode = Try(BucketMode.withName(config.getString(CassandraConfigConstants.BUCKET_TIME_SERIES_MODE))) match {
+        case Success(s) => s
+        case _ => BucketMode.NONE
+      }
+
+      if (timestampType == TimestampType.BUCKETTIMESERIES && bucketMode == BucketMode.NONE) {
+        throw new ConfigException("You should specify a bucketMode while using BUCKETTIMESERIES")
+      }
+
+      if (bucketMode != BucketMode.NONE && bucketFormat.isEmpty) {
+        throw new ConfigException("You should specify a bucketFormat while using BUCKETTIMESERIES")
       }
 
       if (timestampType != TimestampType.NONE && tCols.size != 1) {
@@ -125,7 +148,9 @@ object CassandraSettings extends StrictLogging {
         timeSliceDelay = timeSliceDelay,
         initialOffset = initialOffset,
         timeSliceMillis = timeSliceMillis,
-        mappingCollectionToJson = mappingCollectionToJson
+        mappingCollectionToJson = mappingCollectionToJson,
+        bucketMode = bucketMode,
+        bucketFormat = bucketFormat
       )
     }.toSeq
   }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -65,7 +65,8 @@ case class CassandraSourceSetting(kcql: Kcql,
                                   timeSliceMillis: Long = CassandraConfigConstants.TIME_SLICE_MILLIS_DEFAULT,
                                   mappingCollectionToJson: Boolean = CassandraConfigConstants.MAPPING_COLLECTION_TO_JSON_DEFAULT,
                                   bucketMode: BucketMode,
-                                  bucketFormat: String
+                                  bucketFormat: String,
+                                  bucketFieldName: String
                                  ) extends CassandraSetting
 
 case class CassandraSinkSetting(keySpace: String,
@@ -97,6 +98,7 @@ object CassandraSettings extends StrictLogging {
     val pollInterval = config.getLong(CassandraConfigConstants.POLL_INTERVAL)
 
     val bucketFormat = config.getString(CassandraConfigConstants.BUCKET_TIME_SERIES_FORMAT)
+    val bucketFieldName = config.getString(CassandraConfigConstants.BUCKET_TIME_SERIES_FIELD_NAME)
 
     val consistencyLevel = config.getConsistencyLevel
     val errorPolicy = config.getErrorPolicy
@@ -150,7 +152,8 @@ object CassandraSettings extends StrictLogging {
         timeSliceMillis = timeSliceMillis,
         mappingCollectionToJson = mappingCollectionToJson,
         bucketMode = bucketMode,
-        bucketFormat = bucketFormat
+        bucketFormat = bucketFormat,
+        bucketFieldName = bucketFieldName
       )
     }.toSeq
   }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -185,9 +185,9 @@ class CassandraTableReader(private val name: String,
       preparedStatement.bind(solrQuery)
     } else if (isBucketBased) {
       val buckets = CassandraUtils.getBucketsBetweenDates(previous, upperBound, setting.bucketMode, setting.bucketFormat)
-      val inValues = buckets.mkString(",")
-      logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($inValues, $formattedPrevious, $formattedNow).")
-      preparedStatement.bind(inValues, Date.from(previous), Date.from(upperBound))
+
+      logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow, $buckets).")
+      preparedStatement.bind(Date.from(previous), Date.from(upperBound), buckets)
     } else {
       logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow).")
       preparedStatement.bind(Date.from(previous), Date.from(upperBound))

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -25,6 +25,7 @@ import java.util.{Collections, Date}
 import com.datamountaineer.kcql.FormatType
 import com.datamountaineer.streamreactor.connect.cassandra.config.{CassandraConfigConstants, CassandraSourceSetting, TimestampType}
 import com.datamountaineer.streamreactor.connect.cassandra.utils.CassandraResultSetWrapper.resultSetFutureToScala
+import com.datamountaineer.streamreactor.connect.cassandra.utils.CassandraUtils
 import com.datamountaineer.streamreactor.connect.offsets.OffsetHandler
 import com.datastax.driver.core._
 import com.datastax.driver.core.utils.UUIDs
@@ -72,6 +73,7 @@ class CassandraTableReader(private val name: String,
   private val ignoreList = config.getIgnoredFields.asScala.map(_.getName).toSet
   private val isTokenBased = cqlGenerator.isTokenBased()
   private val isDSESearchBased = cqlGenerator.isDSESearchBased()
+  private val isBucketBased = cqlGenerator.isBucketBased()
   private val cassandraTypeConverter : CassandraTypeConverter =
     new CassandraTypeConverter(session.getCluster.getConfiguration.getCodecRegistry, setting)
   private var structColDefs: List[ColumnDefinitions.Definition] = _
@@ -181,6 +183,11 @@ class CassandraTableReader(private val name: String,
       val solrQuery = "{\"q\": \"" + solrWhere + "\", \"sort\":\"" + primaryKeyCol + " asc\", \"paging\":\"driver\"}"
       logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($solrQuery).")
       preparedStatement.bind(solrQuery)
+    } else if (isBucketBased) {
+      val buckets = CassandraUtils.getBucketsBetweenDates(previous, upperBound, setting.bucketMode, setting.bucketFormat)
+      val inValues = buckets.mkString(",")
+      logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($inValues, $formattedPrevious, $formattedNow).")
+      preparedStatement.bind(inValues, Date.from(previous), Date.from(upperBound))
     } else {
       logger.info(s"Connector $name query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow).")
       preparedStatement.bind(Date.from(previous), Date.from(upperBound))

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtils.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtils.scala
@@ -16,11 +16,17 @@
 
 package com.datamountaineer.streamreactor.connect.cassandra.utils
 
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
 import com.datamountaineer.kcql.Kcql
+import com.datamountaineer.streamreactor.connect.cassandra.config.BucketMode.{BucketMode, DAY, HOUR, MINUTE, SECOND}
 import com.datastax.driver.core.Cluster
 import org.apache.kafka.connect.errors.ConnectException
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 
 /**
   * Created by andrew@datamountaineer.com on 21/04/16.
@@ -46,6 +52,40 @@ object CassandraUtils {
     val missing = topics.toSet.diff(tables.toSet)
 
     if (missing.nonEmpty) throw new ConnectException(s"No tables found in Cassandra for topics ${missing.mkString(",")}")
+  }
+
+  /**
+    * Get buckets between two dates (Instant), this is used within the BUCKETTIMESERIES mode
+    * @param previousDate The first date
+    * @param upperBoundDate The second date
+    * @param bucketMode The bucket mode that is been used on BUCKETTIMESERIES
+    * @param bucketFormat The format of the bucket that is been used BUCKETTIMESERIES
+    *
+    * @return a list of buckets that are between the two dates.
+    */
+  def getBucketsBetweenDates(previousDate: Instant,
+                             upperBoundDate: Instant,
+                             bucketMode: BucketMode,
+                             bucketFormat: String): List[String] = {
+    val unit = bucketMode match {
+      case MINUTE => ChronoUnit.MINUTES
+      case DAY => ChronoUnit.DAYS
+      case HOUR => ChronoUnit.HOURS
+      case SECOND => ChronoUnit.SECONDS
+    }
+    val difference = previousDate.until(upperBoundDate, unit)
+    val formatter = DateTimeFormatter.ofPattern(bucketFormat).withZone(ZoneId.of("UTC"))
+
+    var dates = ListBuffer[String]()
+    dates += formatter.format(previousDate)
+
+    if (difference > 0) {
+      for (f <- 1 to difference.toInt) {
+        dates += formatter.format(previousDate.plus(f, unit))
+      }
+    }
+
+    dates.toList
   }
 
 }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -62,7 +62,7 @@ class TestCqlGenerator extends AnyWordSpec
     val cqlGenerator = new CqlGenerator(configureMeBucketTimeSeries("INCREMENTALMODE=buckettimeseries"))
     val cqlStatement = cqlGenerator.getCqlStatement
 
-    cqlStatement shouldBe "SELECT string_field,the_pk_field FROM test.cassandra-table WHERE bucket IN (?) AND the_pk_field > ? AND the_pk_field <= ?"
+    cqlStatement shouldBe "SELECT string_field,the_pk_field FROM test.cassandra-table WHERE the_pk_field > ? AND the_pk_field <= ? AND bucket IN ?"
   }
 
   "CqlGenerator should generate token based CQL statement based on KCQL" in {

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtilsTest.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtilsTest.scala
@@ -15,7 +15,7 @@ class CassandraUtilsTest extends AnyWordSpec with Matchers {
       val upperBound = Instant.parse("2020-08-12T18:35:24.55Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.SECOND, "yyMMddHHmmss")
-      result.head shouldBe "200812183524"
+      result.get(0) shouldBe "200812183524"
     }
 
     "return correct single bucket from MINUTE bucket" in {
@@ -23,7 +23,7 @@ class CassandraUtilsTest extends AnyWordSpec with Matchers {
       val upperBound = Instant.parse("2020-08-12T18:35:58.10Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.MINUTE, "yyMMddHHmm")
-      result.head shouldBe "2008121835"
+      result.get(0) shouldBe "2008121835"
     }
 
     "return correct single bucket from HOUR bucket" in {
@@ -31,7 +31,7 @@ class CassandraUtilsTest extends AnyWordSpec with Matchers {
       val upperBound = Instant.parse("2020-08-12T18:55:58.10Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.HOUR, "yyMMddHH")
-      result.head shouldBe "20081218"
+      result.get(0) shouldBe "20081218"
     }
 
     "return correct single bucket from DAY bucket" in {
@@ -39,7 +39,7 @@ class CassandraUtilsTest extends AnyWordSpec with Matchers {
       val upperBound = Instant.parse("2020-08-12T23:35:58.10Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.DAY, "yyMMdd")
-      result.head shouldBe "200812"
+      result.get(0) shouldBe "200812"
     }
 
     "return correct multiple buckets from SECOND bucket" in {
@@ -47,25 +47,25 @@ class CassandraUtilsTest extends AnyWordSpec with Matchers {
       val upperBound = Instant.parse("2020-08-12T18:35:28.10Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.SECOND, "yyMMddHHmmss")
-      result.size shouldBe 5
-      result.head shouldBe "200812183524"
-      result(1) shouldBe "200812183525"
-      result(2) shouldBe "200812183526"
-      result(3) shouldBe "200812183527"
-      result(4) shouldBe "200812183528"
+      result.size() shouldBe 5
+      result.get(0) shouldBe "200812183524"
+      result.get(1) shouldBe "200812183525"
+      result.get(2) shouldBe "200812183526"
+      result.get(3) shouldBe "200812183527"
+      result.get(4) shouldBe "200812183528"
     }
 
     "return correct multiple buckets from MINUTE bucket" in {
       val previous = Instant.parse("2020-08-12T18:35:24.00Z");
-      val upperBound = Instant.parse("2020-08-12T18:39:28.10Z");
+      val upperBound = Instant.parse("2020-08-12T18:39:20.10Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.MINUTE, "yyMMddHHmm")
-      result.size shouldBe 5
-      result.head shouldBe "2008121835"
-      result(1) shouldBe "2008121836"
-      result(2) shouldBe "2008121837"
-      result(3) shouldBe "2008121838"
-      result(4) shouldBe "2008121839"
+      result.size() shouldBe 5
+      result.get(0) shouldBe "2008121835"
+      result.get(1) shouldBe "2008121836"
+      result.get(2) shouldBe "2008121837"
+      result.get(3) shouldBe "2008121838"
+      result.get(4) shouldBe "2008121839"
     }
 
     "return correct multiple buckets from HOUR bucket" in {
@@ -73,25 +73,25 @@ class CassandraUtilsTest extends AnyWordSpec with Matchers {
       val upperBound = Instant.parse("2020-08-12T22:39:28.10Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.HOUR, "yyMMddHH")
-      result.size shouldBe 5
-      result.head shouldBe "20081218"
-      result(1) shouldBe "20081219"
-      result(2) shouldBe "20081220"
-      result(3) shouldBe "20081221"
-      result(4) shouldBe "20081222"
+      result.size() shouldBe 5
+      result.get(0) shouldBe "20081218"
+      result.get(1) shouldBe "20081219"
+      result.get(2) shouldBe "20081220"
+      result.get(3) shouldBe "20081221"
+      result.get(4) shouldBe "20081222"
     }
 
     "return correct multiple buckets from DAY bucket" in {
       val previous = Instant.parse("2020-08-12T18:35:24.00Z");
-      val upperBound = Instant.parse("2020-08-16T22:39:28.10Z");
+      val upperBound = Instant.parse("2020-08-16T22:39:20.10Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.DAY, "yyMMdd")
-      result.size shouldBe 5
-      result.head shouldBe "200812"
-      result(1) shouldBe "200813"
-      result(2) shouldBe "200814"
-      result(3) shouldBe "200815"
-      result(4) shouldBe "200816"
+      result.size() shouldBe 5
+      result.get(0) shouldBe "200812"
+      result.get(1) shouldBe "200813"
+      result.get(2) shouldBe "200814"
+      result.get(3) shouldBe "200815"
+      result.get(4) shouldBe "200816"
     }
 
     "return correct quantity of buckets buckets from MINUTE bucket" in {
@@ -99,7 +99,7 @@ class CassandraUtilsTest extends AnyWordSpec with Matchers {
       val upperBound = Instant.parse("2020-09-12T22:39:28.10Z");
 
       val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.MINUTE, "yyMMddHHmm")
-      result.size shouldBe 44885
+      result.size() shouldBe 44885
     }
 
   }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtilsTest.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtilsTest.scala
@@ -1,0 +1,107 @@
+package com.datamountaineer.streamreactor.connect.cassandra.utils
+
+import java.time.Instant
+
+import com.datamountaineer.streamreactor.connect.cassandra.config.BucketMode
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CassandraUtilsTest extends AnyWordSpec with Matchers {
+
+  "CassandraUtilsTest.getBucketsBetweenDates" should {
+
+    "return correct single bucket from SECOND bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-08-12T18:35:24.55Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.SECOND, "yyMMddHHmmss")
+      result.head shouldBe "200812183524"
+    }
+
+    "return correct single bucket from MINUTE bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-08-12T18:35:58.10Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.MINUTE, "yyMMddHHmm")
+      result.head shouldBe "2008121835"
+    }
+
+    "return correct single bucket from HOUR bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-08-12T18:55:58.10Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.HOUR, "yyMMddHH")
+      result.head shouldBe "20081218"
+    }
+
+    "return correct single bucket from DAY bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-08-12T23:35:58.10Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.DAY, "yyMMdd")
+      result.head shouldBe "200812"
+    }
+
+    "return correct multiple buckets from SECOND bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-08-12T18:35:28.10Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.SECOND, "yyMMddHHmmss")
+      result.size shouldBe 5
+      result.head shouldBe "200812183524"
+      result(1) shouldBe "200812183525"
+      result(2) shouldBe "200812183526"
+      result(3) shouldBe "200812183527"
+      result(4) shouldBe "200812183528"
+    }
+
+    "return correct multiple buckets from MINUTE bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-08-12T18:39:28.10Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.MINUTE, "yyMMddHHmm")
+      result.size shouldBe 5
+      result.head shouldBe "2008121835"
+      result(1) shouldBe "2008121836"
+      result(2) shouldBe "2008121837"
+      result(3) shouldBe "2008121838"
+      result(4) shouldBe "2008121839"
+    }
+
+    "return correct multiple buckets from HOUR bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-08-12T22:39:28.10Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.HOUR, "yyMMddHH")
+      result.size shouldBe 5
+      result.head shouldBe "20081218"
+      result(1) shouldBe "20081219"
+      result(2) shouldBe "20081220"
+      result(3) shouldBe "20081221"
+      result(4) shouldBe "20081222"
+    }
+
+    "return correct multiple buckets from DAY bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-08-16T22:39:28.10Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.DAY, "yyMMdd")
+      result.size shouldBe 5
+      result.head shouldBe "200812"
+      result(1) shouldBe "200813"
+      result(2) shouldBe "200814"
+      result(3) shouldBe "200815"
+      result(4) shouldBe "200816"
+    }
+
+    "return correct quantity of buckets buckets from MINUTE bucket" in {
+      val previous = Instant.parse("2020-08-12T18:35:24.00Z");
+      val upperBound = Instant.parse("2020-09-12T22:39:28.10Z");
+
+      val result = CassandraUtils.getBucketsBetweenDates(previous, upperBound, BucketMode.MINUTE, "yyMMddHHmm")
+      result.size shouldBe 44885
+    }
+
+  }
+
+}


### PR DESCRIPTION
We came out with a new incremental mode (different from #663) to avoid ALLOW FILTERING.

**Motivation**
Today we're using the stream-reactor Cassandra Source Connector to stream some data from a Cassandra cluster into some Kafka Topics, with stream-reactor today we only have an option to avoid ALLOW FILTERING on incremental mode, that is using DSESearch.

This PR adds a new INCREMENTALMODE (buckettimeseries) that will add the possibility to make the queries using a technique pretty common on time-series databases, in the case of Cassandra modeling the partition_key is a bucket that divides the documents based on the type of the bucket (MINUTE, HOUR, DAY...) and has a clustering order field that allows the connector to do the **between** operations.

**What we did**
We just added a new INCREMENTALMODE called buckettimeseries that will make queries to Cassandra using the bucket technique.

Instead of the native query:
```sql 
SELECT a, b, c, d FROM keyspace.table WHERE pkCol > ? AND pkCol <= ? ALLOW FILTERING;
```

We will have now the query with Solr on the dsesearchtimestamp INCREMENTALMODE:
```sql
SELECT a, b, c, d FROM keyspace.table WHERE $pkCol > ? AND $pkCol <= ? AND $bucketFieldName IN ?;
```

Where we will have a list of buckets that needs to be used to cover all the time between the partition key query.

**Testing**
You'll gonna find a new test case on the `TestCqlGenerator` and a completely new test file called `CassandraUtilsTest`.

**Additional comments**
We're using this implementation in production for a couple of days and we didn't face any problem, in fact we saw a huge performance improvement from #663.